### PR TITLE
Add group management pages and goal configuration

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "get-after-it-3002a"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yarn-error.log*
 .idea
 .vscode
 .env.local
+.firebase/

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,20 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "hosting": {
+    "public": "dist",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,19 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // This rule allows anyone with your Firestore database reference to view, edit,
+    // and delete all data in your Firestore database. It is useful for getting
+    // started, but it is configured to expire after 30 days because it
+    // leaves your app open to attackers. At that time, all client
+    // requests to your Firestore database will be denied.
+    //
+    // Make sure to write security rules for your app before that time, or else
+    // all client requests to your Firestore database will be denied until you Update
+    // your rules
+    match /{document=**} {
+      allow read, write: if request.time < timestamp.date(2025, 10, 27);
+    }
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,9 @@ import { useState, type ReactNode } from 'react'
 
 import SignIn from './pages/SignIn'
 import SignUp from './pages/SignUp'
+import GroupsList from './pages/GroupsList'
+import CreateGroup from './pages/CreateGroup'
+import GroupDetails from './pages/GroupDetails'
 import { useAuth } from './context/AuthContext'
 
 const router = createBrowserRouter([
@@ -22,7 +25,31 @@ const router = createBrowserRouter([
         index: true,
         element: (
           <RequireAuth>
-            <HomePage />
+            <GroupsList />
+          </RequireAuth>
+        )
+      },
+      {
+        path: 'groups',
+        element: (
+          <RequireAuth>
+            <GroupsList />
+          </RequireAuth>
+        )
+      },
+      {
+        path: 'groups/new',
+        element: (
+          <RequireAuth>
+            <CreateGroup />
+          </RequireAuth>
+        )
+      },
+      {
+        path: 'groups/:groupId',
+        element: (
+          <RequireAuth>
+            <GroupDetails />
           </RequireAuth>
         )
       }
@@ -65,6 +92,12 @@ function RootLayout() {
           <nav className="flex items-center gap-4 text-sm">
             {user ? (
               <>
+                <Link className="text-slate-300 transition hover:text-white" to="/groups">
+                  Groups
+                </Link>
+                <Link className="text-slate-300 transition hover:text-white" to="/groups/new">
+                  Create group
+                </Link>
                 <div className="flex items-center gap-2 text-slate-300">
                   {user.photoURL ? (
                     <img
@@ -102,18 +135,6 @@ function RootLayout() {
         <Outlet />
       </main>
     </div>
-  )
-}
-
-function HomePage() {
-  return (
-    <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-10 shadow-xl shadow-slate-950/40">
-      <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Let&apos;s build something awesome</h1>
-      <p className="mt-4 text-slate-300">
-        Your Firebase powered React experience starts here. Update this page as you flesh out routes,
-        authentication, and data fetching.
-      </p>
-    </section>
   )
 }
 

--- a/src/pages/CreateGroup.tsx
+++ b/src/pages/CreateGroup.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { addDoc, collection, serverTimestamp, setDoc, doc } from 'firebase/firestore'
+
+import { useAuth } from '../context/AuthContext'
+import { db } from '../lib/firebase'
+
+function generateInviteCode() {
+  const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+  let code = ''
+  for (let index = 0; index < 6; index += 1) {
+    const randomIndex = Math.floor(Math.random() * alphabet.length)
+    code += alphabet[randomIndex]
+  }
+  return code
+}
+
+export default function CreateGroup() {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (!user) {
+    return null
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!name.trim()) {
+      setError('A group name is required.')
+      return
+    }
+
+    setCreating(true)
+    setError(null)
+
+    try {
+      const inviteCode = generateInviteCode()
+      const groupData = {
+        name: name.trim(),
+        nameLowercase: name.trim().toLowerCase(),
+        description: description.trim() || null,
+        ownerId: user.uid,
+        inviteCode,
+        createdAt: serverTimestamp()
+      }
+      const groupRef = await addDoc(collection(db, 'groups'), groupData)
+
+      const membershipRef = doc(db, 'groupMembers', `${groupRef.id}_${user.uid}`)
+      await setDoc(membershipRef, {
+        groupId: groupRef.id,
+        userId: user.uid,
+        role: 'owner',
+        joinedAt: serverTimestamp(),
+        displayName: user.displayName ?? user.email ?? 'Owner',
+        photoURL: user.photoURL ?? null
+      })
+
+      navigate(`/groups/${groupRef.id}`)
+    } catch (createError) {
+      console.error(createError)
+      setError('Unable to create group right now. Please try again later.')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <h1 className="text-3xl font-semibold text-white">Create a group</h1>
+      <p className="mt-2 text-sm text-slate-400">
+        Set up a new accountability group and invite friends to join your challenge.
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-8 space-y-6">
+        <div className="space-y-2">
+          <label htmlFor="group-name" className="text-sm font-medium text-slate-200">
+            Group name
+          </label>
+          <input
+            id="group-name"
+            name="group-name"
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Morning Hustlers"
+            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="group-description" className="text-sm font-medium text-slate-200">
+            Description
+          </label>
+          <textarea
+            id="group-description"
+            name="group-description"
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="Describe your challenge or group goals"
+            rows={4}
+            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+          />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={creating}
+            className="inline-flex items-center justify-center rounded-lg bg-sky-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {creating ? 'Creating…' : 'Create group'}
+          </button>
+          {error ? <p className="text-sm text-red-400">{error}</p> : null}
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/pages/GroupDetails.tsx
+++ b/src/pages/GroupDetails.tsx
@@ -1,0 +1,406 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import {
+  Timestamp,
+  collection,
+  doc,
+  onSnapshot,
+  query,
+  serverTimestamp,
+  setDoc,
+  where
+} from 'firebase/firestore'
+
+import { useAuth } from '../context/AuthContext'
+import { db } from '../lib/firebase'
+
+type Group = {
+  id: string
+  name: string
+  description?: string
+  inviteCode: string
+  ownerId: string
+}
+
+type Member = {
+  id: string
+  userId: string
+  displayName: string
+  photoURL: string | null
+  role: 'owner' | 'member'
+  joinedAt?: Timestamp
+}
+
+type Goal = {
+  id: string
+  groupId: string
+  challengeType: string
+  targetValue: number
+  createdAt?: Timestamp
+}
+
+export default function GroupDetails() {
+  const { groupId } = useParams<{ groupId: string }>()
+  const { user } = useAuth()
+  const [group, setGroup] = useState<Group | null>(null)
+  const [members, setMembers] = useState<Member[]>([])
+  const [membership, setMembership] = useState<Member | null>(null)
+  const [goal, setGoal] = useState<Goal | null>(null)
+  const [goalChallengeType, setGoalChallengeType] = useState('')
+  const [goalTargetValue, setGoalTargetValue] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [savingGoal, setSavingGoal] = useState(false)
+  const [goalMessage, setGoalMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!groupId) {
+      return
+    }
+
+    const groupRef = doc(db, 'groups', groupId)
+    const unsubscribe = onSnapshot(
+      groupRef,
+      (snapshot) => {
+        if (!snapshot.exists()) {
+          setGroup(null)
+          setError('Group not found.')
+          setLoading(false)
+          return
+        }
+
+        const data = snapshot.data()
+        const descriptionValue = data.description
+        setGroup({
+          id: snapshot.id,
+          name: data.name as string,
+          description:
+            typeof descriptionValue === 'string' && descriptionValue.length
+              ? descriptionValue
+              : undefined,
+          inviteCode: data.inviteCode as string,
+          ownerId: data.ownerId as string
+        })
+        setLoading(false)
+      },
+      (snapshotError) => {
+        console.error(snapshotError)
+        setError('Failed to load group details.')
+        setLoading(false)
+      }
+    )
+
+    return () => unsubscribe()
+  }, [groupId])
+
+  useEffect(() => {
+    if (!groupId) {
+      return
+    }
+
+    const membershipsQuery = query(
+      collection(db, 'groupMembers'),
+      where('groupId', '==', groupId)
+    )
+
+    const unsubscribe = onSnapshot(
+      membershipsQuery,
+      (snapshot) => {
+        const memberDocs: Member[] = snapshot.docs.map((docSnapshot) => {
+          const data = docSnapshot.data()
+          return {
+            id: docSnapshot.id,
+            userId: data.userId as string,
+            displayName:
+              typeof data.displayName === 'string' && data.displayName.length
+                ? (data.displayName as string)
+                : 'Member',
+            photoURL: (data.photoURL as string | null) ?? null,
+            role: (data.role as 'owner' | 'member') ?? 'member',
+            joinedAt: data.joinedAt as Timestamp | undefined
+          }
+        })
+        memberDocs.sort((first, second) => {
+          if (first.role === 'owner' && second.role !== 'owner') {
+            return -1
+          }
+          if (first.role !== 'owner' && second.role === 'owner') {
+            return 1
+          }
+          const firstTime = first.joinedAt?.toMillis() ?? 0
+          const secondTime = second.joinedAt?.toMillis() ?? 0
+          return firstTime - secondTime
+        })
+        setMembers(memberDocs)
+      },
+      (snapshotError) => {
+        console.error(snapshotError)
+        setError('Unable to load group members.')
+      }
+    )
+
+    return () => unsubscribe()
+  }, [groupId])
+
+  useEffect(() => {
+    if (!groupId || !user) {
+      return
+    }
+
+    const membershipRef = doc(db, 'groupMembers', `${groupId}_${user.uid}`)
+    const unsubscribe = onSnapshot(membershipRef, (snapshot) => {
+      if (!snapshot.exists()) {
+        setMembership(null)
+        return
+      }
+      const data = snapshot.data()
+      setMembership({
+        id: snapshot.id,
+        userId: data.userId as string,
+        displayName:
+          typeof data.displayName === 'string' && data.displayName.length
+            ? (data.displayName as string)
+            : 'Member',
+        photoURL: (data.photoURL as string | null) ?? null,
+        role: (data.role as 'owner' | 'member') ?? 'member',
+        joinedAt: data.joinedAt as Timestamp | undefined
+      })
+    })
+
+    return () => unsubscribe()
+  }, [groupId, user])
+
+  useEffect(() => {
+    if (!groupId) {
+      return
+    }
+
+    const goalRef = doc(db, 'goals', groupId)
+    const unsubscribe = onSnapshot(goalRef, (snapshot) => {
+      if (!snapshot.exists()) {
+        setGoal(null)
+        setGoalChallengeType('')
+        setGoalTargetValue('')
+        return
+      }
+
+      const data = snapshot.data()
+      const challengeType = (data.challengeType as string) ?? ''
+      const targetValue = data.targetValue as number | undefined
+      setGoal({
+        id: snapshot.id,
+        groupId: (data.groupId as string) ?? groupId,
+        challengeType,
+        targetValue: typeof targetValue === 'number' ? targetValue : 0,
+        createdAt: data.createdAt as Timestamp | undefined
+      })
+      setGoalChallengeType(challengeType)
+      setGoalTargetValue(
+        typeof targetValue === 'number' && Number.isFinite(targetValue)
+          ? String(targetValue)
+          : ''
+      )
+    })
+
+    return () => unsubscribe()
+  }, [groupId])
+
+  const isOwner = useMemo(() => membership?.role === 'owner', [membership])
+
+  const handleSaveGoal = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!groupId || !isOwner) {
+      return
+    }
+
+    if (!goalChallengeType.trim()) {
+      setGoalMessage('Please provide a challenge type.')
+      return
+    }
+
+    const parsedTargetValue = Number(goalTargetValue)
+    if (!Number.isFinite(parsedTargetValue) || parsedTargetValue <= 0) {
+      setGoalMessage('Target value must be a positive number.')
+      return
+    }
+
+    setSavingGoal(true)
+    setGoalMessage(null)
+
+    try {
+      const goalRef = doc(db, 'goals', groupId)
+      await setDoc(
+        goalRef,
+        {
+          groupId,
+          challengeType: goalChallengeType.trim(),
+          targetValue: parsedTargetValue,
+          updatedAt: serverTimestamp(),
+          createdAt: goal?.createdAt ?? serverTimestamp()
+        },
+        { merge: true }
+      )
+      setGoalMessage('Goal updated!')
+    } catch (saveError) {
+      console.error(saveError)
+      setGoalMessage('Unable to save goal right now.')
+    } finally {
+      setSavingGoal(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-20 text-slate-300">
+        <span>Loading group…</span>
+      </div>
+    )
+  }
+
+  if (!group) {
+    return (
+      <div className="space-y-4 text-slate-300">
+        <p>We couldn&apos;t find that group.</p>
+        <Link
+          to="/groups"
+          className="text-sm font-medium text-sky-400 transition hover:text-sky-300"
+        >
+          Back to groups
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-10">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold text-white">{group.name}</h1>
+          {group.description ? (
+            <p className="mt-2 text-sm text-slate-300">{group.description}</p>
+          ) : null}
+          <p className="mt-4 text-xs uppercase tracking-wide text-slate-500">
+            Invite code: <span className="font-mono text-slate-300">{group.inviteCode}</span>
+          </p>
+        </div>
+        <Link
+          to="/groups"
+          className="inline-flex items-center justify-center rounded-lg border border-slate-700 px-3 py-1 text-sm font-medium text-slate-200 transition hover:border-sky-500 hover:text-white"
+        >
+          Back to groups
+        </Link>
+      </div>
+
+      {membership ? null : (
+        <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-6 text-amber-100">
+          <p className="font-medium">You&apos;re viewing this group as a guest.</p>
+          <p className="mt-2 text-sm">
+            Ask the owner for the invite code to join and participate in the challenge.
+          </p>
+        </div>
+      )}
+
+      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/60">
+        <h2 className="text-lg font-semibold text-white">Current goal</h2>
+        {goal ? (
+          <div className="mt-4 space-y-2 text-sm text-slate-300">
+            <p>
+              Challenge: <span className="font-medium text-white">{goal.challengeType}</span>
+            </p>
+            <p>
+              Target: <span className="font-medium text-white">{goal.targetValue}</span>
+            </p>
+          </div>
+        ) : (
+          <p className="mt-4 text-sm text-slate-400">No goal configured yet.</p>
+        )}
+
+        {isOwner ? (
+          <form onSubmit={handleSaveGoal} className="mt-6 space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="challenge-type" className="text-sm font-medium text-slate-200">
+                Challenge type
+              </label>
+              <input
+                id="challenge-type"
+                type="text"
+                value={goalChallengeType}
+                onChange={(event) => setGoalChallengeType(event.target.value)}
+                placeholder="Workout days"
+                className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="target-value" className="text-sm font-medium text-slate-200">
+                Target value
+              </label>
+              <input
+                id="target-value"
+                type="number"
+                min="1"
+                value={goalTargetValue}
+                onChange={(event) => setGoalTargetValue(event.target.value)}
+                placeholder="5"
+                className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+              />
+            </div>
+
+            <div className="flex items-center gap-3">
+              <button
+                type="submit"
+                disabled={savingGoal}
+                className="inline-flex items-center justify-center rounded-lg bg-sky-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {savingGoal ? 'Saving…' : 'Save goal'}
+              </button>
+              {goalMessage ? <p className="text-sm text-slate-300">{goalMessage}</p> : null}
+            </div>
+          </form>
+        ) : null}
+      </section>
+
+      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/60">
+        <h2 className="text-lg font-semibold text-white">Members</h2>
+        {members.length ? (
+          <ul className="mt-4 space-y-3">
+            {members.map((member) => (
+              <li
+                key={member.id}
+                className="flex items-center justify-between gap-4 rounded-lg border border-slate-800 bg-slate-950/60 px-4 py-3"
+              >
+                <div className="flex items-center gap-3">
+                  {member.photoURL ? (
+                    <img
+                      src={member.photoURL}
+                      alt={member.displayName}
+                      className="h-8 w-8 rounded-full object-cover"
+                      referrerPolicy="no-referrer"
+                    />
+                  ) : (
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-800 text-xs font-semibold uppercase text-slate-200">
+                      {member.displayName.charAt(0)}
+                    </div>
+                  )}
+                  <div>
+                    <p className="text-sm font-medium text-white">{member.displayName}</p>
+                    <p className="text-xs uppercase tracking-wide text-slate-500">{member.role}</p>
+                  </div>
+                </div>
+                {member.joinedAt ? (
+                  <p className="text-xs text-slate-500">
+                    Joined {member.joinedAt.toDate().toLocaleDateString()}
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-4 text-sm text-slate-400">No members yet.</p>
+        )}
+      </section>
+
+      {error ? <p className="text-sm text-red-400">{error}</p> : null}
+    </div>
+  )
+}

--- a/src/pages/GroupsList.tsx
+++ b/src/pages/GroupsList.tsx
@@ -1,0 +1,399 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  Timestamp,
+  collection,
+  doc,
+  endAt,
+  getDoc,
+  getDocs,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  setDoc,
+  startAt,
+  where
+} from 'firebase/firestore'
+
+import { db } from '../lib/firebase'
+import { useAuth } from '../context/AuthContext'
+
+type Group = {
+  id: string
+  name: string
+  description?: string
+  inviteCode: string
+  ownerId: string
+}
+
+type Membership = {
+  id: string
+  groupId: string
+  role: 'owner' | 'member'
+  joinedAt?: Timestamp
+}
+
+export default function GroupsList() {
+  const { user } = useAuth()
+  const [groups, setGroups] = useState<Group[]>([])
+  const [memberships, setMemberships] = useState<Record<string, Membership>>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [inviteCode, setInviteCode] = useState('')
+  const [joining, setJoining] = useState(false)
+  const [joinMessage, setJoinMessage] = useState<string | null>(null)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [searching, setSearching] = useState(false)
+  const [searchResults, setSearchResults] = useState<Group[]>([])
+
+  useEffect(() => {
+    if (!user) {
+      return
+    }
+
+    const membershipsQuery = query(
+      collection(db, 'groupMembers'),
+      where('userId', '==', user.uid)
+    )
+
+    const unsubscribe = onSnapshot(
+      membershipsQuery,
+      async (snapshot) => {
+        const membershipDocs: Membership[] = snapshot.docs.map((docSnapshot) => {
+          const data = docSnapshot.data()
+          return {
+            id: docSnapshot.id,
+            groupId: data.groupId as string,
+            role: data.role as 'owner' | 'member',
+            joinedAt: data.joinedAt as Timestamp | undefined
+          }
+        })
+
+        setMemberships(
+          membershipDocs.reduce((acc, membershipDoc) => {
+            acc[membershipDoc.groupId] = membershipDoc
+            return acc
+          }, {} as Record<string, Membership>)
+        )
+
+        if (!membershipDocs.length) {
+          setGroups([])
+          setLoading(false)
+          return
+        }
+
+        try {
+          const groupSnapshots = await Promise.all(
+            membershipDocs.map((membershipDoc) =>
+              getDoc(doc(db, 'groups', membershipDoc.groupId))
+            )
+          )
+
+          const groupData = groupSnapshots
+            .filter((groupSnapshot) => groupSnapshot.exists())
+            .map((groupSnapshot) => {
+              const data = groupSnapshot.data()
+              const descriptionValue = data.description
+              return {
+                id: groupSnapshot.id,
+                name: data.name as string,
+                description:
+                  typeof descriptionValue === 'string' && descriptionValue.length
+                    ? descriptionValue
+                    : undefined,
+                inviteCode: data.inviteCode as string,
+                ownerId: data.ownerId as string
+              }
+            })
+
+          setGroups(groupData)
+        } catch (groupError) {
+          console.error(groupError)
+          setError('Failed to load groups')
+        } finally {
+          setLoading(false)
+        }
+      },
+      (snapshotError) => {
+        console.error(snapshotError)
+        setError('Failed to load memberships')
+        setLoading(false)
+      }
+    )
+
+    return () => unsubscribe()
+  }, [user])
+
+  useEffect(() => {
+    let isCurrent = true
+
+    const runSearch = async () => {
+      if (!searchTerm.trim()) {
+        setSearchResults([])
+        setSearching(false)
+        return
+      }
+
+      setSearching(true)
+      setError(null)
+      try {
+        const normalized = searchTerm.trim().toLowerCase()
+        const searchQuery = query(
+          collection(db, 'groups'),
+          orderBy('nameLowercase'),
+          startAt(normalized),
+          endAt(`${normalized}\uf8ff`),
+          limit(10)
+        )
+        const snapshot = await getDocs(searchQuery)
+        if (!isCurrent) return
+        const results: Group[] = snapshot.docs.map((docSnapshot) => {
+          const data = docSnapshot.data()
+          const descriptionValue = data.description
+          return {
+            id: docSnapshot.id,
+            name: data.name as string,
+            description:
+              typeof descriptionValue === 'string' && descriptionValue.length
+                ? descriptionValue
+                : undefined,
+            inviteCode: data.inviteCode as string,
+            ownerId: data.ownerId as string
+          }
+        })
+        setSearchResults(results)
+      } catch (searchError) {
+        console.error(searchError)
+        if (isCurrent) {
+          setError('Search failed. Try a different term.')
+        }
+      } finally {
+        if (isCurrent) {
+          setSearching(false)
+        }
+      }
+    }
+
+    void runSearch()
+
+    return () => {
+      isCurrent = false
+    }
+  }, [searchTerm])
+
+  const handleJoinByCode = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!user || !inviteCode.trim()) {
+      return
+    }
+
+    setJoining(true)
+    setJoinMessage(null)
+    setError(null)
+
+    try {
+      const code = inviteCode.trim().toUpperCase()
+      const codeQuery = query(
+        collection(db, 'groups'),
+        where('inviteCode', '==', code),
+        limit(1)
+      )
+      const snapshot = await getDocs(codeQuery)
+
+      if (snapshot.empty) {
+        setJoinMessage('No group found with that invite code.')
+        return
+      }
+
+      const groupDoc = snapshot.docs[0]
+      if (memberships[groupDoc.id]) {
+        setJoinMessage('You are already a member of that group.')
+        return
+      }
+      await joinGroup(groupDoc.id, groupDoc.data().inviteCode as string)
+      setJoinMessage('Joined group successfully!')
+      setInviteCode('')
+    } catch (joinError) {
+      console.error(joinError)
+      setError('Unable to join group right now. Please try again later.')
+    } finally {
+      setJoining(false)
+    }
+  }
+
+  const joinGroup = async (groupId: string, code: string) => {
+    if (!user) return
+    if (memberships[groupId]) return
+
+    const membershipRef = doc(db, 'groupMembers', `${groupId}_${user.uid}`)
+    await setDoc(
+      membershipRef,
+      {
+        groupId,
+        userId: user.uid,
+        role: memberships[groupId]?.role ?? 'member',
+        joinedAt: memberships[groupId]?.joinedAt ?? serverTimestamp(),
+        displayName: user.displayName ?? user.email ?? 'Member',
+        photoURL: user.photoURL ?? null,
+        inviteCodeUsed: code
+      },
+      { merge: true }
+    )
+  }
+
+  const handleSearchJoin = async (group: Group) => {
+    try {
+      await joinGroup(group.id, group.inviteCode)
+      setJoinMessage(`Joined ${group.name}`)
+    } catch (joinError) {
+      console.error(joinError)
+      setError('Unable to join that group right now.')
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-20 text-slate-300">
+        <span>Loading your groups…</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-10">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold text-white">Your groups</h1>
+          <p className="text-sm text-slate-400">
+            Join an existing challenge or create a new accountability group.
+          </p>
+        </div>
+        <Link
+          to="/groups/new"
+          className="inline-flex items-center justify-center rounded-lg bg-sky-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-sky-400"
+        >
+          Create group
+        </Link>
+      </header>
+
+      <section className="grid gap-6 md:grid-cols-2">
+        {groups.length ? (
+          groups.map((group) => (
+            <article
+              key={group.id}
+              className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/60"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-xl font-semibold text-white">{group.name}</h2>
+                  {group.description ? (
+                    <p className="mt-2 text-sm text-slate-300">{group.description}</p>
+                  ) : null}
+                  <p className="mt-3 text-xs uppercase tracking-wide text-slate-500">
+                    Invite code: <span className="font-mono text-slate-300">{group.inviteCode}</span>
+                  </p>
+                </div>
+                <Link
+                  to={`/groups/${group.id}`}
+                  className="rounded-lg border border-slate-700 px-3 py-1 text-sm font-medium text-slate-200 transition hover:border-sky-500 hover:text-white"
+                >
+                  View
+                </Link>
+              </div>
+            </article>
+          ))
+        ) : (
+          <div className="rounded-xl border border-dashed border-slate-800 p-10 text-center text-slate-400">
+            <p className="font-medium text-slate-300">No groups yet</p>
+            <p className="mt-2 text-sm">
+              Create your first group or join one with an invite code.
+            </p>
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/60">
+        <h2 className="text-lg font-semibold text-white">Join with invite code</h2>
+        <p className="mt-2 text-sm text-slate-400">
+          Ask a friend for their group&apos;s invite code to hop in instantly.
+        </p>
+        <form onSubmit={handleJoinByCode} className="mt-4 flex flex-col gap-3 sm:flex-row">
+          <input
+            type="text"
+            value={inviteCode}
+            onChange={(event) => setInviteCode(event.target.value.toUpperCase())}
+            placeholder="ENTER CODE"
+            className="flex-1 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+          />
+          <button
+            type="submit"
+            disabled={joining}
+            className="inline-flex items-center justify-center rounded-lg bg-sky-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {joining ? 'Joining…' : 'Join group'}
+          </button>
+        </form>
+        {joinMessage ? (
+          <p className="mt-3 text-sm text-slate-300">{joinMessage}</p>
+        ) : null}
+      </section>
+
+      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/60">
+        <h2 className="text-lg font-semibold text-white">Find groups</h2>
+        <p className="mt-2 text-sm text-slate-400">
+          Search for public groups by name and request to join instantly.
+        </p>
+        <div className="mt-4 flex flex-col gap-3">
+          <input
+            type="search"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="Search for groups"
+            className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+          />
+          {searching ? (
+            <p className="text-sm text-slate-400">Searching…</p>
+          ) : null}
+          <div className="space-y-3">
+            {searchResults.map((group) => {
+              const alreadyMember = Boolean(memberships[group.id])
+              return (
+                <div
+                  key={group.id}
+                  className="flex flex-col justify-between gap-3 rounded-lg border border-slate-800 bg-slate-950/60 p-4 sm:flex-row sm:items-center"
+                >
+                  <div>
+                    <p className="font-medium text-white">{group.name}</p>
+                    {group.description ? (
+                      <p className="text-sm text-slate-400">{group.description}</p>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Link
+                      to={`/groups/${group.id}`}
+                      className="rounded-lg border border-slate-700 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-300 transition hover:border-sky-500 hover:text-white"
+                    >
+                      View
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => handleSearchJoin(group)}
+                      disabled={alreadyMember}
+                      className="rounded-lg bg-sky-500 px-3 py-1 text-xs font-medium uppercase tracking-wide text-white transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {alreadyMember ? 'Member' : 'Join'}
+                    </button>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      {error ? <p className="text-sm text-red-400">{error}</p> : null}
+    </div>
+  )
+}

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/app.tsx","./src/main.tsx","./src/vite-env.d.ts","./src/context/authcontext.tsx","./src/lib/firebase.ts","./src/pages/signin.tsx","./src/pages/signup.tsx"],"version":"5.9.2"}


### PR DESCRIPTION
## Summary
- add protected routes for listing groups, creating groups, and viewing group details
- implement Firestore-backed group list with invite-code join and search support
- create group details view with member roster and owner goal configuration form

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d82622c8b883299340978d85d2ee40