### PR TITLE
Add light mode theme toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import {
   useLocation,
   useNavigate
 } from 'react-router-dom'
-import { useState, type ReactNode } from 'react'
+import { useState, type ReactNode, useMemo } from 'react'
 
 import SignIn from './pages/SignIn'
 import SignUp from './pages/SignUp'
@@ -15,6 +15,7 @@ import GroupsList from './pages/GroupsList'
 import CreateGroup from './pages/CreateGroup'
 import GroupDetails from './pages/GroupDetails'
 import { useAuth } from './context/AuthContext'
+import { useTheme } from './context/useTheme'
 
 const router = createBrowserRouter([
   {
@@ -69,6 +70,33 @@ function RootLayout() {
   const { user, signOut } = useAuth()
   const navigate = useNavigate()
   const [signingOut, setSigningOut] = useState(false)
+  const { theme, toggleTheme } = useTheme()
+  const isDark = theme === 'dark'
+
+  const navLinkClass = useMemo(
+    () =>
+      `transition ${
+        isDark
+          ? 'text-slate-300 hover:text-white'
+          : 'text-slate-600 hover:text-slate-900'
+      }`,
+    [isDark]
+  )
+
+  const brandTextClass = isDark ? 'text-white' : 'text-slate-900'
+  const headerBorderClass = isDark ? 'border-slate-800' : 'border-slate-200'
+  const userTextClass = isDark ? 'text-slate-300' : 'text-slate-700'
+  const actionButtonClass = `rounded-lg border px-3 py-1 text-sm font-medium transition ${
+    isDark
+      ? 'border-slate-700 text-slate-200 hover:border-sky-500 hover:text-white'
+      : 'border-slate-300 text-slate-700 hover:border-sky-500 hover:text-slate-900'
+  }`
+
+  const themeButtonClass = `rounded-lg px-3 py-1 text-sm font-medium transition ${
+    isDark
+      ? 'border border-slate-700 text-slate-200 hover:border-sky-500 hover:text-white'
+      : 'border border-slate-300 text-slate-700 hover:border-sky-500 hover:text-slate-900'
+  }`
 
   const handleSignOut = async () => {
     try {
@@ -82,23 +110,35 @@ function RootLayout() {
     }
   }
 
+  const themeButtonLabel = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-slate-800">
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-          <Link to="/" className="text-lg font-semibold text-white">
+    <div
+      className={`min-h-screen bg-slate-50 text-slate-900 transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100`}
+    >
+      <header className={`border-b ${headerBorderClass}`}>
+        <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-3 px-6 py-4">
+          <Link to="/" className={`text-lg font-semibold ${brandTextClass}`}>
             Get After It
           </Link>
-          <nav className="flex items-center gap-4 text-sm">
+          <nav className="flex flex-wrap items-center gap-3 text-sm">
+            <button
+              type="button"
+              onClick={toggleTheme}
+              className={themeButtonClass}
+              aria-label={themeButtonLabel}
+            >
+              {theme === 'dark' ? 'Light mode' : 'Dark mode'}
+            </button>
             {user ? (
               <>
-                <Link className="text-slate-300 transition hover:text-white" to="/groups">
+                <Link className={navLinkClass} to="/groups">
                   Groups
                 </Link>
-                <Link className="text-slate-300 transition hover:text-white" to="/groups/new">
+                <Link className={navLinkClass} to="/groups/new">
                   Create group
                 </Link>
-                <div className="flex items-center gap-2 text-slate-300">
+                <div className={`flex items-center gap-2 ${userTextClass}`}>
                   {user.photoURL ? (
                     <img
                       src={user.photoURL}
@@ -113,17 +153,17 @@ function RootLayout() {
                   type="button"
                   disabled={signingOut}
                   onClick={handleSignOut}
-                  className="rounded-lg border border-slate-700 px-3 py-1 text-sm font-medium text-slate-200 transition hover:border-sky-500 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+                  className={`${actionButtonClass} disabled:cursor-not-allowed disabled:opacity-60`}
                 >
                   {signingOut ? 'Signing out…' : 'Sign out'}
                 </button>
               </>
             ) : (
               <>
-                <Link className="text-slate-300 transition hover:text-white" to="/sign-in">
+                <Link className={navLinkClass} to="/sign-in">
                   Sign in
                 </Link>
-                <Link className="text-slate-300 transition hover:text-white" to="/sign-up">
+                <Link className={navLinkClass} to="/sign-up">
                   Sign up
                 </Link>
               </>
@@ -144,7 +184,7 @@ function RequireAuth({ children }: { children: ReactNode }) {
 
   if (loading) {
     return (
-      <div className="flex justify-center py-20 text-slate-300">
+      <div className="flex justify-center py-20 text-slate-500 dark:text-slate-300">
         <span>Loading…</span>
       </div>
     )

--- a/src/context/ThemeContext.shared.ts
+++ b/src/context/ThemeContext.shared.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react'
+
+type Theme = 'light' | 'dark'
+
+type ThemeContextValue = {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+  toggleTheme: () => void
+}
+
+export const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+export type { Theme, ThemeContextValue }

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+
+import { ThemeContext, type Theme, type ThemeContextValue } from './ThemeContext.shared'
+
+const STORAGE_KEY = 'user-theme-preference'
+
+function getSystemPreference(): Theme {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return 'dark'
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'dark'
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  if (stored === 'light' || stored === 'dark') {
+    return stored
+  }
+
+  return getSystemPreference()
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  function applyTheme(nextTheme: Theme) {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const root = window.document.documentElement
+    root.dataset.theme = nextTheme
+    root.style.colorScheme = nextTheme
+
+    if (nextTheme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+  }
+
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const initial = getInitialTheme()
+    applyTheme(initial)
+    return initial
+  })
+
+  useEffect(() => {
+    applyTheme(theme)
+
+    if (typeof window === 'undefined') {
+      return
+    }
+    window.localStorage.setItem(STORAGE_KEY, theme)
+  }, [theme])
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      setTheme: setThemeState,
+      toggleTheme: () => {
+        setThemeState((current) => (current === 'dark' ? 'light' : 'dark'))
+      }
+    }),
+    [theme]
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export type { Theme }

--- a/src/context/useTheme.ts
+++ b/src/context/useTheme.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react'
+
+import { ThemeContext } from './ThemeContext.shared'
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+
+  return context
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,13 +3,28 @@
 @tailwind utilities;
 
 :root {
+  color-scheme: light;
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+:root[data-theme='dark'] {
   color-scheme: dark;
+  background-color: #020617;
+  color: #f8fafc;
+}
+
+:root[data-theme='light'] {
+  color-scheme: light;
+  background-color: #f8fafc;
+  color: #0f172a;
 }
 
 body {
   margin: 0;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #020617;
+  background-color: inherit;
+  color: inherit;
 }
 
 a {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,14 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
 import { AuthProvider } from './context/AuthContext'
+import { ThemeProvider } from './context/ThemeContext'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </ThemeProvider>
   </React.StrictMode>
 )

--- a/src/pages/CreateGroup.tsx
+++ b/src/pages/CreateGroup.tsx
@@ -70,14 +70,14 @@ export default function CreateGroup() {
 
   return (
     <div className="mx-auto max-w-2xl">
-      <h1 className="text-3xl font-semibold text-white">Create a group</h1>
-      <p className="mt-2 text-sm text-slate-400">
+      <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">Create a group</h1>
+      <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
         Set up a new accountability group and invite friends to join your challenge.
       </p>
 
       <form onSubmit={handleSubmit} className="mt-8 space-y-6">
         <div className="space-y-2">
-          <label htmlFor="group-name" className="text-sm font-medium text-slate-200">
+          <label htmlFor="group-name" className="text-sm font-medium text-slate-700 dark:text-slate-200">
             Group name
           </label>
           <input
@@ -87,12 +87,12 @@ export default function CreateGroup() {
             value={name}
             onChange={(event) => setName(event.target.value)}
             placeholder="Morning Hustlers"
-            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+            className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
           />
         </div>
 
         <div className="space-y-2">
-          <label htmlFor="group-description" className="text-sm font-medium text-slate-200">
+          <label htmlFor="group-description" className="text-sm font-medium text-slate-700 dark:text-slate-200">
             Description
           </label>
           <textarea
@@ -102,7 +102,7 @@ export default function CreateGroup() {
             onChange={(event) => setDescription(event.target.value)}
             placeholder="Describe your challenge or group goals"
             rows={4}
-            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+            className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
           />
         </div>
 
@@ -114,7 +114,9 @@ export default function CreateGroup() {
           >
             {creating ? 'Creating…' : 'Create group'}
           </button>
-          {error ? <p className="text-sm text-red-400">{error}</p> : null}
+          {error ? (
+            <p className="text-sm text-rose-600 dark:text-red-400">{error}</p>
+          ) : null}
         </div>
       </form>
     </div>

--- a/src/pages/GroupDetails.tsx
+++ b/src/pages/GroupDetails.tsx
@@ -570,7 +570,7 @@ export default function GroupDetails() {
 
   if (loading) {
     return (
-      <div className="flex justify-center py-20 text-slate-300">
+      <div className="flex justify-center py-20 text-slate-500 dark:text-slate-300">
         <span>Loading group…</span>
       </div>
     )
@@ -578,11 +578,11 @@ export default function GroupDetails() {
 
   if (!group) {
     return (
-      <div className="space-y-4 text-slate-300">
+      <div className="space-y-4 text-slate-600 dark:text-slate-300">
         <p>We couldn&apos;t find that group.</p>
         <Link
           to="/groups"
-          className="text-sm font-medium text-sky-400 transition hover:text-sky-300"
+          className="text-sm font-medium text-sky-600 transition hover:text-sky-500 dark:text-sky-400 dark:hover:text-sky-300"
         >
           Back to groups
         </Link>
@@ -594,24 +594,25 @@ export default function GroupDetails() {
     <div className="space-y-10">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-3xl font-semibold text-white">{group.name}</h1>
+          <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">{group.name}</h1>
           {group.description ? (
-            <p className="mt-2 text-sm text-slate-300">{group.description}</p>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{group.description}</p>
           ) : null}
-          <p className="mt-4 text-xs uppercase tracking-wide text-slate-500">
-            Invite code: <span className="font-mono text-slate-300">{group.inviteCode}</span>
+          <p className="mt-4 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Invite code:{' '}
+            <span className="font-mono text-slate-800 dark:text-slate-300">{group.inviteCode}</span>
           </p>
         </div>
         <Link
           to="/groups"
-          className="inline-flex items-center justify-center rounded-lg border border-slate-700 px-3 py-1 text-sm font-medium text-slate-200 transition hover:border-sky-500 hover:text-white"
+          className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-3 py-1 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-slate-900 dark:border-slate-700 dark:text-slate-200 dark:hover:text-white"
         >
           Back to groups
         </Link>
       </div>
 
       {membership ? null : (
-        <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-6 text-amber-100">
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100">
           <p className="font-medium">You&apos;re viewing this group as a guest.</p>
           <p className="mt-2 text-sm">
             Ask the owner for the invite code to join and participate in the challenge.
@@ -619,16 +620,17 @@ export default function GroupDetails() {
         </div>
       )}
 
-      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/60">
-        <h2 className="text-lg font-semibold text-white">Current goal</h2>
+      <section className="rounded-xl border border-slate-200 bg-slate-50 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/60">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Current goal</h2>
         {goal ? (
-          <div className="mt-4 space-y-2 text-sm text-slate-300">
+          <div className="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-300">
             <p>
-              Challenge: <span className="font-medium text-white">{goal.challengeType}</span>
+              Challenge:{' '}
+              <span className="font-medium text-slate-900 dark:text-white">{goal.challengeType}</span>
             </p>
             <p>
               Goal type:{' '}
-              <span className="font-medium text-white">
+              <span className="font-medium text-slate-900 dark:text-white">
                 {goal.goalType === 'daily'
                   ? 'Daily habit (one log per day)'
                   : 'Numeric total'}
@@ -636,29 +638,29 @@ export default function GroupDetails() {
             </p>
             <p>
               {goal.goalType === 'daily' ? 'Target days' : 'Target total'}:{' '}
-              <span className="font-medium text-white">{goal.targetValue}</span>
+              <span className="font-medium text-slate-900 dark:text-white">{goal.targetValue}</span>
             </p>
             <p>
               {goal.goalType === 'daily' ? 'Group days logged' : 'Group total logged'}:{' '}
-              <span className="font-medium text-white">{aggregatedProgress.groupTotal}</span>
+              <span className="font-medium text-slate-900 dark:text-white">{aggregatedProgress.groupTotal}</span>
             </p>
             {goal.targetValue ? (
               <p>
                 Progress:{' '}
-                <span className="font-medium text-white">
+                <span className="font-medium text-slate-900 dark:text-white">
                   {Math.min(aggregatedProgress.groupTotal, goal.targetValue)}/{goal.targetValue}
                 </span>
               </p>
             ) : null}
           </div>
         ) : (
-          <p className="mt-4 text-sm text-slate-400">No goal configured yet.</p>
+          <p className="mt-4 text-sm text-slate-600 dark:text-slate-400">No goal configured yet.</p>
         )}
 
         {isOwner ? (
           <form onSubmit={handleSaveGoal} className="mt-6 space-y-4">
             <div className="space-y-2">
-              <label htmlFor="challenge-type" className="text-sm font-medium text-slate-200">
+              <label htmlFor="challenge-type" className="text-sm font-medium text-slate-700 dark:text-slate-200">
                 Challenge type
               </label>
               <input
@@ -667,12 +669,12 @@ export default function GroupDetails() {
                 value={goalChallengeType}
                 onChange={(event) => setGoalChallengeType(event.target.value)}
                 placeholder="Workout days"
-                className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
               />
             </div>
 
             <div className="space-y-2">
-              <label htmlFor="goal-type" className="text-sm font-medium text-slate-200">
+              <label htmlFor="goal-type" className="text-sm font-medium text-slate-700 dark:text-slate-200">
                 Goal type
               </label>
               <select
@@ -681,7 +683,7 @@ export default function GroupDetails() {
                 onChange={(event) =>
                   setGoalType(event.target.value === 'daily' ? 'daily' : 'numeric')
                 }
-                className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
               >
                 <option value="numeric">Numeric total (minutes, miles, reps, etc.)</option>
                 <option value="daily">Daily habit (log once per day)</option>
@@ -689,7 +691,7 @@ export default function GroupDetails() {
             </div>
 
             <div className="space-y-2">
-              <label htmlFor="target-value" className="text-sm font-medium text-slate-200">
+              <label htmlFor="target-value" className="text-sm font-medium text-slate-700 dark:text-slate-200">
                 Target value
               </label>
               <input
@@ -699,7 +701,7 @@ export default function GroupDetails() {
                 value={goalTargetValue}
                 onChange={(event) => setGoalTargetValue(event.target.value)}
                 placeholder="5"
-                className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
               />
             </div>
 
@@ -711,13 +713,15 @@ export default function GroupDetails() {
               >
                 {savingGoal ? 'Saving…' : 'Save goal'}
               </button>
-              {goalMessage ? <p className="text-sm text-slate-300">{goalMessage}</p> : null}
+              {goalMessage ? (
+                <p className="text-sm text-slate-600 dark:text-slate-300">{goalMessage}</p>
+              ) : null}
             </div>
             <button
               type="button"
               onClick={handleResetChallenge}
               disabled={resettingChallenge}
-              className="inline-flex items-center justify-center rounded-lg border border-red-500/60 px-4 py-2 text-sm font-medium text-red-300 transition hover:border-red-400 hover:text-red-200 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center justify-center rounded-lg border border-red-200 px-4 py-2 text-sm font-medium text-red-600 transition hover:border-red-400 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-500/60 dark:text-red-300 dark:hover:border-red-400 dark:hover:text-red-200"
             >
               {resettingChallenge ? 'Resetting…' : 'Reset challenge'}
             </button>
@@ -725,13 +729,13 @@ export default function GroupDetails() {
         ) : null}
       </section>
 
-      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/60">
-        <h2 className="text-lg font-semibold text-white">Log progress</h2>
+      <section className="rounded-xl border border-slate-200 bg-slate-50 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/60">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Log progress</h2>
         {membership ? (
           <form onSubmit={handleSaveProgress} className="mt-4 space-y-4">
             <div className="grid gap-4 sm:grid-cols-3">
               <div className="space-y-2">
-                <label htmlFor="progress-date" className="text-sm font-medium text-slate-200">
+                <label htmlFor="progress-date" className="text-sm font-medium text-slate-700 dark:text-slate-200">
                   Date
                 </label>
                 <input
@@ -740,19 +744,19 @@ export default function GroupDetails() {
                   value={progressDate}
                   max={new Date().toISOString().slice(0, 10)}
                   onChange={(event) => setProgressDate(event.target.value)}
-                  className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+                  className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
                 />
               </div>
               {goal?.goalType === 'daily' ? (
                 <div className="space-y-2">
-                  <p className="text-sm font-medium text-slate-200">Daily log</p>
-                  <p className="rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-300">
+                  <p className="text-sm font-medium text-slate-700 dark:text-slate-200">Daily log</p>
+                  <p className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-300">
                     Each submission counts as one day completed.
                   </p>
                 </div>
               ) : (
                 <div className="space-y-2">
-                  <label htmlFor="progress-quantity" className="text-sm font-medium text-slate-200">
+                  <label htmlFor="progress-quantity" className="text-sm font-medium text-slate-700 dark:text-slate-200">
                     Quantity
                   </label>
                   <input
@@ -763,12 +767,12 @@ export default function GroupDetails() {
                     value={progressQuantity}
                     onChange={(event) => setProgressQuantity(event.target.value)}
                     placeholder="1"
-                    className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+                    className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
                   />
                 </div>
               )}
               <div className="space-y-2 sm:col-span-3">
-                <label htmlFor="progress-notes" className="text-sm font-medium text-slate-200">
+                <label htmlFor="progress-notes" className="text-sm font-medium text-slate-700 dark:text-slate-200">
                   Notes (optional)
                 </label>
                 <textarea
@@ -777,7 +781,7 @@ export default function GroupDetails() {
                   onChange={(event) => setProgressNotes(event.target.value)}
                   placeholder="What did you accomplish today?"
                   rows={3}
-                  className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+                  className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
                 />
               </div>
             </div>
@@ -789,16 +793,20 @@ export default function GroupDetails() {
               >
                 {savingProgress ? 'Saving…' : 'Log progress'}
               </button>
-              {progressMessage ? <p className="text-sm text-slate-300">{progressMessage}</p> : null}
-              {progressError ? <p className="text-sm text-red-400">{progressError}</p> : null}
+              {progressMessage ? (
+                <p className="text-sm text-slate-600 dark:text-slate-300">{progressMessage}</p>
+              ) : null}
+              {progressError ? (
+                <p className="text-sm text-rose-600 dark:text-red-400">{progressError}</p>
+              ) : null}
             </div>
           </form>
         ) : (
-          <p className="mt-4 text-sm text-slate-400">Join the group to log your progress.</p>
+          <p className="mt-4 text-sm text-slate-600 dark:text-slate-400">Join the group to log your progress.</p>
         )}
 
         <div className="mt-6">
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
             Group history
           </h3>
           {historyEntries.length ? (
@@ -811,34 +819,34 @@ export default function GroupDetails() {
                 return (
                   <li
                     key={entry.id}
-                    className="rounded-lg border border-slate-800 bg-slate-950/60 px-4 py-3 text-sm text-slate-300"
+                    className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-950/60 dark:text-slate-300"
                   >
                     <div className="flex flex-wrap items-center justify-between gap-2">
                       <div>
-                        <p className="text-sm font-medium text-white">{entry.displayName}</p>
-                        <p className="text-xs text-slate-500">
+                        <p className="text-sm font-medium text-slate-900 dark:text-white">{entry.displayName}</p>
+                        <p className="text-xs text-slate-500 dark:text-slate-400">
                           {createdDate.toLocaleString()}
                         </p>
                       </div>
-                      <span className="text-emerald-400">{entry.displayQuantity}</span>
+                      <span className="text-emerald-600 dark:text-emerald-400">{entry.displayQuantity}</span>
                     </div>
                     {entry.notes ? (
-                      <p className="mt-2 text-xs text-slate-400">{entry.notes}</p>
+                      <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">{entry.notes}</p>
                     ) : null}
                   </li>
                 )
               })}
             </ul>
           ) : (
-            <p className="mt-3 text-sm text-slate-400">No progress logged yet.</p>
+            <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">No progress logged yet.</p>
           )}
         </div>
       </section>
 
-      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/60">
-        <h2 className="text-lg font-semibold text-white">Leaderboard</h2>
+      <section className="rounded-xl border border-slate-200 bg-slate-50 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/60">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Leaderboard</h2>
         {goal && aggregatedProgress.winners.length ? (
-          <div className="mt-4 rounded-lg border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+          <div className="mt-4 rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100">
             <p className="font-medium">
               {aggregatedProgress.winners.length > 1 ? 'We have winners!' : 'We have a winner!'}
             </p>
@@ -856,7 +864,7 @@ export default function GroupDetails() {
             {aggregatedProgress.rows.map((row) => (
               <li
                 key={row.userId}
-                className="flex flex-col gap-2 rounded-lg border border-slate-800 bg-slate-950/60 px-4 py-3 text-sm text-slate-300 sm:flex-row sm:items-center sm:justify-between"
+                className="flex flex-col gap-2 rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between dark:border-slate-800 dark:bg-slate-950/60 dark:text-slate-300"
               >
                 <div className="flex items-center gap-3">
                   {row.photoURL ? (
@@ -872,13 +880,13 @@ export default function GroupDetails() {
                     </div>
                   )}
                   <div>
-                    <p className="text-sm font-medium text-white">{row.displayName}</p>
+                    <p className="text-sm font-medium text-slate-900 dark:text-white">{row.displayName}</p>
                     {row.completedAt ? (
-                      <p className="text-xs text-emerald-400">
+                      <p className="text-xs text-emerald-600 dark:text-emerald-400">
                         Goal met on {row.completedAt.toLocaleDateString()}
                       </p>
                     ) : (
-                      <p className="text-xs text-slate-500">
+                      <p className="text-xs text-slate-500 dark:text-slate-400">
                         {goal?.goalType === 'daily'
                           ? `${row.entries.length} ${row.entries.length === 1 ? 'day' : 'days'} logged`
                           : `${row.entries.length} entr${row.entries.length === 1 ? 'y' : 'ies'}`}
@@ -886,7 +894,7 @@ export default function GroupDetails() {
                     )}
                   </div>
                 </div>
-                <p className="text-sm font-semibold text-sky-300">
+                <p className="text-sm font-semibold text-sky-600 dark:text-sky-300">
                   {goal?.goalType === 'daily'
                     ? `${row.total} day${row.total === 1 ? '' : 's'}`
                     : row.total}
@@ -895,18 +903,18 @@ export default function GroupDetails() {
             ))}
           </ul>
         ) : (
-          <p className="mt-4 text-sm text-slate-400">No progress logged yet.</p>
+          <p className="mt-4 text-sm text-slate-600 dark:text-slate-400">No progress logged yet.</p>
         )}
       </section>
 
-      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/60">
-        <h2 className="text-lg font-semibold text-white">Members</h2>
+      <section className="rounded-xl border border-slate-200 bg-slate-50 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/60">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Members</h2>
         {members.length ? (
           <ul className="mt-4 space-y-3">
             {members.map((member) => (
               <li
                 key={member.id}
-                className="flex items-center justify-between gap-4 rounded-lg border border-slate-800 bg-slate-950/60 px-4 py-3"
+                className="flex items-center justify-between gap-4 rounded-lg border border-slate-200 bg-white px-4 py-3 dark:border-slate-800 dark:bg-slate-950/60"
               >
                 <div className="flex items-center gap-3">
                   {member.photoURL ? (
@@ -922,12 +930,12 @@ export default function GroupDetails() {
                     </div>
                   )}
                   <div>
-                    <p className="text-sm font-medium text-white">{member.displayName}</p>
-                    <p className="text-xs uppercase tracking-wide text-slate-500">{member.role}</p>
+                    <p className="text-sm font-medium text-slate-900 dark:text-white">{member.displayName}</p>
+                    <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{member.role}</p>
                   </div>
                 </div>
                 {member.joinedAt ? (
-                  <p className="text-xs text-slate-500">
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
                     Joined {member.joinedAt.toDate().toLocaleDateString()}
                   </p>
                 ) : null}
@@ -935,11 +943,11 @@ export default function GroupDetails() {
             ))}
           </ul>
         ) : (
-          <p className="mt-4 text-sm text-slate-400">No members yet.</p>
+          <p className="mt-4 text-sm text-slate-600 dark:text-slate-400">No members yet.</p>
         )}
       </section>
 
-      {error ? <p className="text-sm text-red-400">{error}</p> : null}
+      {error ? <p className="text-sm text-rose-600 dark:text-red-400">{error}</p> : null}
     </div>
   )
 }

--- a/src/pages/GroupsList.tsx
+++ b/src/pages/GroupsList.tsx
@@ -255,7 +255,7 @@ export default function GroupsList() {
 
   if (loading) {
     return (
-      <div className="flex justify-center py-20 text-slate-300">
+      <div className="flex justify-center py-20 text-slate-500 dark:text-slate-300">
         <span>Loading your groups…</span>
       </div>
     )
@@ -265,8 +265,8 @@ export default function GroupsList() {
     <div className="space-y-10">
       <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-3xl font-semibold text-white">Your groups</h1>
-          <p className="text-sm text-slate-400">
+          <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">Your groups</h1>
+          <p className="text-sm text-slate-600 dark:text-slate-400">
             Join an existing challenge or create a new accountability group.
           </p>
         </div>
@@ -283,21 +283,22 @@ export default function GroupsList() {
           groups.map((group) => (
             <article
               key={group.id}
-              className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/60"
+              className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/60"
             >
               <div className="flex items-start justify-between gap-4">
                 <div>
-                  <h2 className="text-xl font-semibold text-white">{group.name}</h2>
+                  <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{group.name}</h2>
                   {group.description ? (
-                    <p className="mt-2 text-sm text-slate-300">{group.description}</p>
+                    <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{group.description}</p>
                   ) : null}
-                  <p className="mt-3 text-xs uppercase tracking-wide text-slate-500">
-                    Invite code: <span className="font-mono text-slate-300">{group.inviteCode}</span>
+                  <p className="mt-3 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    Invite code:{' '}
+                    <span className="font-mono text-slate-700 dark:text-slate-300">{group.inviteCode}</span>
                   </p>
                 </div>
                 <Link
                   to={`/groups/${group.id}`}
-                  className="rounded-lg border border-slate-700 px-3 py-1 text-sm font-medium text-slate-200 transition hover:border-sky-500 hover:text-white"
+                  className="rounded-lg border border-slate-300 px-3 py-1 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-slate-900 dark:border-slate-700 dark:text-slate-200 dark:hover:text-white"
                 >
                   View
                 </Link>
@@ -305,8 +306,8 @@ export default function GroupsList() {
             </article>
           ))
         ) : (
-          <div className="rounded-xl border border-dashed border-slate-800 p-10 text-center text-slate-400">
-            <p className="font-medium text-slate-300">No groups yet</p>
+          <div className="rounded-xl border border-dashed border-slate-300 p-10 text-center text-slate-600 dark:border-slate-800 dark:text-slate-400">
+            <p className="font-medium text-slate-700 dark:text-slate-300">No groups yet</p>
             <p className="mt-2 text-sm">
               Create your first group or join one with an invite code.
             </p>
@@ -314,9 +315,9 @@ export default function GroupsList() {
         )}
       </section>
 
-      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/60">
-        <h2 className="text-lg font-semibold text-white">Join with invite code</h2>
-        <p className="mt-2 text-sm text-slate-400">
+      <section className="rounded-xl border border-slate-200 bg-slate-50 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/60">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Join with invite code</h2>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
           Ask a friend for their group&apos;s invite code to hop in instantly.
         </p>
         <form onSubmit={handleJoinByCode} className="mt-4 flex flex-col gap-3 sm:flex-row">
@@ -325,7 +326,7 @@ export default function GroupsList() {
             value={inviteCode}
             onChange={(event) => setInviteCode(event.target.value.toUpperCase())}
             placeholder="ENTER CODE"
-            className="flex-1 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+            className="flex-1 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
           />
           <button
             type="submit"
@@ -336,13 +337,13 @@ export default function GroupsList() {
           </button>
         </form>
         {joinMessage ? (
-          <p className="mt-3 text-sm text-slate-300">{joinMessage}</p>
+          <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{joinMessage}</p>
         ) : null}
       </section>
 
-      <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/60">
-        <h2 className="text-lg font-semibold text-white">Find groups</h2>
-        <p className="mt-2 text-sm text-slate-400">
+      <section className="rounded-xl border border-slate-200 bg-slate-50 p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/60">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Find groups</h2>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
           Search for public groups by name and request to join instantly.
         </p>
         <div className="mt-4 flex flex-col gap-3">
@@ -351,10 +352,10 @@ export default function GroupsList() {
             value={searchTerm}
             onChange={(event) => setSearchTerm(event.target.value)}
             placeholder="Search for groups"
-            className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+            className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
           />
           {searching ? (
-            <p className="text-sm text-slate-400">Searching…</p>
+            <p className="text-sm text-slate-600 dark:text-slate-400">Searching…</p>
           ) : null}
           <div className="space-y-3">
             {searchResults.map((group) => {
@@ -362,18 +363,18 @@ export default function GroupsList() {
               return (
                 <div
                   key={group.id}
-                  className="flex flex-col justify-between gap-3 rounded-lg border border-slate-800 bg-slate-950/60 p-4 sm:flex-row sm:items-center"
+                  className="flex flex-col justify-between gap-3 rounded-lg border border-slate-200 bg-white p-4 sm:flex-row sm:items-center dark:border-slate-800 dark:bg-slate-950/60"
                 >
                   <div>
-                    <p className="font-medium text-white">{group.name}</p>
+                    <p className="font-medium text-slate-900 dark:text-white">{group.name}</p>
                     {group.description ? (
-                      <p className="text-sm text-slate-400">{group.description}</p>
+                      <p className="text-sm text-slate-600 dark:text-slate-400">{group.description}</p>
                     ) : null}
                   </div>
                   <div className="flex items-center gap-2">
                     <Link
                       to={`/groups/${group.id}`}
-                      className="rounded-lg border border-slate-700 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-300 transition hover:border-sky-500 hover:text-white"
+                      className="rounded-lg border border-slate-300 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 transition hover:border-sky-500 hover:text-slate-900 dark:border-slate-700 dark:text-slate-300 dark:hover:text-white"
                     >
                       View
                     </Link>
@@ -393,7 +394,7 @@ export default function GroupsList() {
         </div>
       </section>
 
-      {error ? <p className="text-sm text-red-400">{error}</p> : null}
+      {error ? <p className="text-sm text-rose-600 dark:text-red-400">{error}</p> : null}
     </div>
   )
 }

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -64,9 +64,9 @@ export default function SignIn() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-md rounded-2xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-slate-950/30">
-      <h1 className="text-2xl font-semibold text-white">Sign in to your account</h1>
-      <p className="mt-2 text-sm text-slate-400">
+    <div className="mx-auto w-full max-w-md rounded-2xl border border-slate-200 bg-white p-8 shadow-xl shadow-slate-200/50 dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/30">
+      <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Sign in to your account</h1>
+      <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
         New here?{' '}
         <Link to="/sign-up" className="font-medium text-sky-400 hover:text-sky-300">
           Create an account
@@ -75,7 +75,7 @@ export default function SignIn() {
 
       <form onSubmit={handleSubmit} className="mt-8 space-y-5">
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-slate-300">
+          <label htmlFor="email" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
             Email
           </label>
           <input
@@ -83,14 +83,14 @@ export default function SignIn() {
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
-            className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+            className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner shadow-slate-200/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:shadow-slate-950/50"
             required
             autoComplete="email"
             disabled={formBusy || loading}
           />
         </div>
         <div>
-          <label htmlFor="password" className="block text-sm font-medium text-slate-300">
+          <label htmlFor="password" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
             Password
           </label>
           <input
@@ -98,7 +98,7 @@ export default function SignIn() {
             type="password"
             value={password}
             onChange={(event) => setPassword(event.target.value)}
-            className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+            className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner shadow-slate-200/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:shadow-slate-950/50"
             required
             autoComplete="current-password"
             disabled={formBusy || loading}
@@ -106,7 +106,7 @@ export default function SignIn() {
         </div>
 
         {error ? (
-          <p className="text-sm text-rose-400">{error}</p>
+          <p className="text-sm text-rose-600 dark:text-rose-400">{error}</p>
         ) : null}
 
         <button
@@ -123,7 +123,7 @@ export default function SignIn() {
           type="button"
           onClick={handleGoogleSignIn}
           disabled={formBusy || loading}
-          className="flex w-full items-center justify-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-white transition hover:border-sky-500 disabled:cursor-not-allowed disabled:border-slate-800"
+          className="flex w-full items-center justify-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-slate-900 disabled:cursor-not-allowed dark:border-slate-700 dark:text-white dark:hover:text-white dark:hover:border-sky-500"
         >
           <span>Continue with Google</span>
         </button>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -95,9 +95,9 @@ export default function SignUp() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-md rounded-2xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-slate-950/30">
-      <h1 className="text-2xl font-semibold text-white">Create your account</h1>
-      <p className="mt-2 text-sm text-slate-400">
+    <div className="mx-auto w-full max-w-md rounded-2xl border border-slate-200 bg-white p-8 shadow-xl shadow-slate-200/50 dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/30">
+      <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Create your account</h1>
+      <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
         Already have an account?{' '}
         <Link to="/sign-in" className="font-medium text-sky-400 hover:text-sky-300">
           Sign in
@@ -106,33 +106,33 @@ export default function SignUp() {
 
       <form onSubmit={handleSubmit} className="mt-8 space-y-5">
         <div>
-          <label htmlFor="displayName" className="block text-sm font-medium text-slate-300">
+          <label htmlFor="displayName" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
             Display name
           </label>
           <input
             id="displayName"
             value={displayName}
             onChange={(event) => setDisplayName(event.target.value)}
-            className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+            className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner shadow-slate-200/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:shadow-slate-950/50"
             placeholder="What should we call you?"
             disabled={formBusy || loading}
           />
         </div>
         <div>
-          <label htmlFor="photoURL" className="block text-sm font-medium text-slate-300">
+          <label htmlFor="photoURL" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
             Avatar URL
           </label>
           <input
             id="photoURL"
             value={photoURL}
             onChange={(event) => setPhotoURL(event.target.value)}
-            className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+            className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner shadow-slate-200/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:shadow-slate-950/50"
             placeholder="https://example.com/avatar.png"
             disabled={formBusy || loading}
           />
         </div>
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-slate-300">
+          <label htmlFor="email" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
             Email
           </label>
           <input
@@ -140,14 +140,14 @@ export default function SignUp() {
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
-            className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+            className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner shadow-slate-200/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:shadow-slate-950/50"
             required
             autoComplete="email"
             disabled={formBusy || loading}
           />
         </div>
         <div>
-          <label htmlFor="password" className="block text-sm font-medium text-slate-300">
+          <label htmlFor="password" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
             Password
           </label>
           <input
@@ -155,14 +155,14 @@ export default function SignUp() {
             type="password"
             value={password}
             onChange={(event) => setPassword(event.target.value)}
-            className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+            className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner shadow-slate-200/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:shadow-slate-950/50"
             required
             autoComplete="new-password"
             disabled={formBusy || loading}
           />
         </div>
         <div>
-          <label htmlFor="confirmPassword" className="block text-sm font-medium text-slate-300">
+          <label htmlFor="confirmPassword" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
             Confirm password
           </label>
           <input
@@ -170,14 +170,14 @@ export default function SignUp() {
             type="password"
             value={confirmPassword}
             onChange={(event) => setConfirmPassword(event.target.value)}
-            className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+            className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner shadow-slate-200/50 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:shadow-slate-950/50"
             required
             autoComplete="new-password"
             disabled={formBusy || loading}
           />
         </div>
 
-        {error ? <p className="text-sm text-rose-400">{error}</p> : null}
+        {error ? <p className="text-sm text-rose-600 dark:text-rose-400">{error}</p> : null}
 
         <button
           type="submit"
@@ -193,7 +193,7 @@ export default function SignUp() {
           type="button"
           onClick={handleGoogleSignUp}
           disabled={formBusy || loading}
-          className="flex w-full items-center justify-center gap-2 rounded-lg border border-slate-700 px-4 py-2 text-sm font-medium text-white transition hover:border-sky-500 disabled:cursor-not-allowed disabled:border-slate-800"
+          className="flex w-full items-center justify-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-sky-500 hover:text-slate-900 disabled:cursor-not-allowed dark:border-slate-700 dark:text-white dark:hover:text-white dark:hover:border-sky-500"
         >
           <span>Sign up with Google</span>
         </button>


### PR DESCRIPTION
## Summary
- introduce a theme provider with persistent user preference and a reusable hook
- update layout and authentication/group pages to support both light and dark styling with a toggle in the header
- refresh global styles for theme-aware colors and backgrounds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8a3a818808329b0228492f01e9d7e